### PR TITLE
Fix replace next when visible only is selected and add checkbox for

### DIFF
--- a/assets/popup.html
+++ b/assets/popup.html
@@ -84,6 +84,12 @@
         </tr>
         <tr>
             <td>
+                <label for="wholeWord">Match whole word?</label>
+                <input name="wholeWord" id="wholeWord" type="checkbox"/>
+            </td>
+        </tr>
+        <tr>
+            <td>
                 <label for="regex">Regular Expression?</label>
                 <input name="regex" id="regex" type="checkbox"/>
             </td>

--- a/background.ts
+++ b/background.ts
@@ -11,6 +11,7 @@ chrome.runtime.onConnect.addListener(function (port) {
                     'case': msg['case'],
                     'inputFieldsOnly': msg['inputFieldsOnly'],
                     'visibleOnly': msg['visibleOnly'],
+                    'wholeWord': msg['wholeWord'],
                     'regex': msg['regex']
                 }
             }, function () {
@@ -25,6 +26,7 @@ chrome.runtime.onConnect.addListener(function (port) {
                         'case': result.options['case'],
                         inputFieldsOnly: result.options['inputFieldsOnly'],
                         visibleOnly: result.options['visibleOnly'],
+                        wholeWord: result.options['wholeWord'],
                         regex: result.options['regex']
                     })
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -44,6 +44,6 @@
     "https://*/*"
   ],
   "update_url": "http://clients2.google.com/service/update2/crx",
-  "version": "1.4.9"
+  "version": "1.4.10"
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search_and_replace",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "resolutions": {
   "author": "Chris Taylor <cjtaylor38@gmail.com>"
   },


### PR DESCRIPTION
Fixes replace next when visible only is selected.

Adds a `wholeWord` checkbox that adds the boundary operator to the search when selected.