### PR TITLE
Reload pages when `preferredLanguage` is changed

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -65,10 +65,7 @@ window.addEventListener('DOMContentLoaded', async function () {
         languageSelect.addEventListener('change', function () {
             const selectedLanguage = this.value
 
-            chrome.storage.sync.set({ preferredLanguage: selectedLanguage }, function () {
-                // Reload the current page to apply the language change
-                location.reload()
-            })
+            chrome.storage.sync.set({ preferredLanguage: selectedLanguage })
         })
     }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -150,6 +150,13 @@ export function createTranslationProxy(translationData: LangFile): TranslationPr
 
 // Function to localize HTML elements using translation data
 export function localizeElements(translationData: LangFile) {
+    chrome.storage.onChanged.addListener((changes, areaName) => {
+        if (areaName === 'sync' && 'preferredLanguage' in changes) {
+            // Reload the page when the preferredLanguage is changed
+            location.reload()
+        }
+    })
+
     document.querySelectorAll('[data-locale]').forEach((elem) => {
         const element = elem as HTMLElement
         const localeKey = element.getAttribute('data-locale')


### PR DESCRIPTION
Pages will be reloaded automatically when `preferredLanguage` changes, without the user having to reload them.